### PR TITLE
Fix language set

### DIFF
--- a/tls-inspector/App.swift
+++ b/tls-inspector/App.swift
@@ -21,6 +21,10 @@ import TLSUI
 struct TLSInspectorApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
+    init() {
+        UserOptions.bootstrapLanguage()
+    }
+
     var body: some Scene {
         WindowGroup {
             MainView()

--- a/tls-inspector/AppDelegate.swift
+++ b/tls-inspector/AppDelegate.swift
@@ -19,6 +19,7 @@ import TLSKit
 import DNSKit
 import TLSUI
 
+@MainActor
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         TLSKit.log = LogWriter.shared

--- a/tlsui/Sources/TLSUI/Services/UserOptions.swift
+++ b/tlsui/Sources/TLSUI/Services/UserOptions.swift
@@ -81,7 +81,13 @@ private final class AppDefaults: Sendable {
     }
 }
 
+@MainActor
 public final class UserOptions: ObservableObject {
+    public static func bootstrapLanguage() {
+        let selectedLanguage = SupportedLanguages.init(rawValue: AppDefaults.get(.appLanguage)) ?? .English
+        currentLanguage = selectedLanguage
+    }
+
     public init() {
         verboseLogging = AppDefaults.get(.verboseLogging)
         firstRunComplete = AppDefaults.get(.firstRunComplete)
@@ -97,9 +103,11 @@ public final class UserOptions: ObservableObject {
         advancedSettingsNagDismissed = AppDefaults.get(.advancedSettingsNagDismissed)
         cryptoEngine = CryptoEngine.init(rawValue: AppDefaults.get(.cryptoEngine)) ?? .NetworkFramework
         ipVersion = IPVersion.init(rawValue: AppDefaults.get(.ipVersion)) ?? .Automatic
-        appLanguage = SupportedLanguages.init(rawValue: AppDefaults.get(.appLanguage)) ?? .English
+        let selectedLanguage = SupportedLanguages.init(rawValue: AppDefaults.get(.appLanguage)) ?? .English
+        appLanguage = selectedLanguage
         treatUnrecognizedAsTrusted = AppDefaults.get(.treatUnrecognizedAsTrusted)
         inspectTimeout = AppDefaults.get(.inspectTimeout)
+        currentLanguage = selectedLanguage
     }
 
     @Published public var verboseLogging: Bool {


### PR DESCRIPTION
Currently, the application starts in English despite a different language being selected in settings.

Changes description:
* Added code that checks the selected language before launching the application and starts the application using that language.
* Added code that checks the system language on first launch and, if it is supported by the application, sets it as the application language.

Swift is not my strong suit, but I tried to integrate the code correctly.